### PR TITLE
fix: start next with esm false

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,3 +1,6 @@
 module.exports = {
   reactStrictMode: true,
+  experimental: {
+    esmExternals: false
+  }
 }


### PR DESCRIPTION
Fixing Heap of memory on `next start` turning `esmExternals` to `false`

Thanks to [this issue on next repo](https://github.com/vercel/next.js/issues/30425#issuecomment-952821295) :tada: 